### PR TITLE
fix: tagged objects schema - select path and region after creation

### DIFF
--- a/gmc/markup_objects/polygon.py
+++ b/gmc/markup_objects/polygon.py
@@ -171,6 +171,9 @@ class EditableMarkupPolygon(MarkupPolygon):
             MarkupObjectMeta.mouseDoubleClickEvent(self, event)
 
     def notify_delete(self) -> None:
+        """
+        User pressed "Del" on `MoveableDiamond`, we get notified
+        """
         indices: list[int] = []
         for item in self.childItems():
             if isinstance(item, MoveableDiamond) and item.isSelected():
@@ -233,7 +236,7 @@ class EditableMarkupPolygon(MarkupPolygon):
         # important: there's no strong enough reason to remove one point paths
         self.setFlag(self.ItemIsSelectable, True)
         self.on_change_polygon(self._polygon)
-        self.after_creation()
+        self.on_created()
         return True
 
     def mouse_move(self, event: QtGui.QMouseEvent, view: ImageView) -> bool:
@@ -256,7 +259,7 @@ class EditableMarkupPolygon(MarkupPolygon):
         view.scene().removeItem(self)
         view.set_mouse_press(self.mouse_press)  # start over
 
-    def after_creation(self):
+    def on_created(self):
         pass
 
 

--- a/gmc/schemas/fields.py
+++ b/gmc/schemas/fields.py
@@ -59,7 +59,7 @@ class CustomPath(HasTags, EditableMarkupPolygon):
     def tag_pos(self):
         return self._polygon[0]
 
-    def after_creation(self):
+    def on_created(self):
         if self._base:
             self._schema._add_m_broken_line_action.trigger()
         else:
@@ -94,7 +94,7 @@ class CustomRegion(CustomPath):
     def shape(self):
         return EditableMarkupPolygon.shape(self)
 
-    def after_creation(self):
+    def on_created(self):
         if self._base:
             self._schema._add_m_region_action.trigger()
         else:

--- a/gmc/schemas/tagged_objects/__init__.py
+++ b/gmc/schemas/tagged_objects/__init__.py
@@ -106,6 +106,11 @@ def from_json_rect(
     raise ValueError(f"incorrect rect `{data}`")
 
 
+def _select_on_created(self: Any) -> None:
+    self.setSelected(True)
+    self._schema.on_object_created(self)
+
+
 @with_brush
 class CustomQuadrangle(HasTags, Quadrangle):
     from_json = classmethod(from_json_polygon)
@@ -125,9 +130,7 @@ class CustomQuadrangle(HasTags, Quadrangle):
         painter.setBrush(self._current_color)
         super().paint(painter, option, widget)
 
-    def on_created(self) -> None:
-        self.setSelected(True)
-        self._schema.on_object_created(self)
+    on_created = _select_on_created
 
     def tag_pos(self) -> QtCore.QPointF:
         return self._polygon.at(1)
@@ -187,9 +190,7 @@ class CustomPoint(HasTags, MarkupPoint):
             self.PEN = MarkupPoint.PEN
         super()._on_tags_changed()
 
-    def on_created(self) -> None:
-        self.setSelected(True)
-        self._schema.on_object_created(self)
+    on_created = _select_on_created
 
     def tag_pos(self):
         return QtCore.QPointF()
@@ -209,9 +210,7 @@ class CustomRectangle(HasTags, MarkupRect):
         painter.setBrush(self._current_color)
         super().paint(painter, option, widget)
 
-    def on_created(self) -> None:
-        self.setSelected(True)
-        self._schema.on_object_created(self)
+    on_created = _select_on_created
 
     def tag_pos(self):
         return self._rect.topRight()
@@ -248,8 +247,7 @@ class CustomPath(HasTags, EditableMarkupPolygon):
     def tag_pos(self) -> QtCore.QPointF:
         return self._polygon[0]
 
-    def after_creation(self):
-        self._schema.on_object_created(self)
+    on_created = _select_on_created
 
 
 @with_brush

--- a/tests/test_tagged_objects.py
+++ b/tests/test_tagged_objects.py
@@ -67,7 +67,6 @@ class TaggedObjectsTest(unittest.TestCase):
             "size": [640, 480],
         }
         self.assertEqual(dict(schema._get_markup()), ref_region_markup)
-        view.select_all_action.trigger()
         view.delete_action.trigger()
         self.assertEqual(schema._get_markup(), self.REF_EMPTY_MARKUP)
         view.undo_action.trigger()


### PR DESCRIPTION
unified `on_created` method